### PR TITLE
Added missing ws-util project. Versions 0.2.0 and 0.3.0 are broken.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val commonRootSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(core, testUtil, ws, wsTestUtil)
+  .aggregate(core, testUtil, ws, wsUtil, wsTestUtil)
   .settings(commonRootSettings ++ Seq(
     publish := {},
     publishArtifact := false


### PR DESCRIPTION
@audax-shreyaspurohit @mingy711 @macmacbr @danstaley

_facepalm_ this was causing missing dependency issues. The old releases 0.2.0 and 0.3.0 are broken.
