### PR TITLE
Support concat and ident

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,6 @@ lazy val commonSettings = commonRootSettings ++ Seq(
     compilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.12"),
     "com.typesafe.play" %% "play-json" % playVersion,  // TODO: Allow using other Json libraries
     "org.scalacheck" %% "scalacheck" % scalacheckVersion,
-    "org.scalactic" %% "scalactic" % scalatestVersion,
     "org.scalatest" %% "scalatest" % scalatestVersion % "test"
   ),
 

--- a/core/src/main/scala/me/jeffmay/neo4j/client/Neo4jClient.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/Neo4jClient.scala
@@ -1,6 +1,6 @@
 package me.jeffmay.neo4j.client
 
-import me.jeffmay.neo4j.client.cypher.Statement
+import me.jeffmay.neo4j.client.cypher.CypherStatement
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -12,13 +12,13 @@ trait Neo4jClient {
   def changePassword(newPassword: String): Future[Unit]
 
   // TODO: Use a single statement return type
-  def openAndCommitTxn(first: Statement, others: Statement*): Future[CommittedTxnResponse]
+  def openAndCommitTxn(first: CypherStatement, others: CypherStatement*): Future[CommittedTxnResponse]
 
   // TODO: Use a single statement return type
-  def openTxn(statements: Statement*): Future[OpenedTxnResponse]
+  def openTxn(statements: CypherStatement*): Future[OpenedTxnResponse]
 
   // TODO: Use a single statement return type
-  def commitTxn(ref: TxnRef, alongWith: Statement*): Future[CommittedTxnResponse]
+  def commitTxn(ref: TxnRef, alongWith: CypherStatement*): Future[CommittedTxnResponse]
 
   def withStatsIncludedByDefault(includeStatsByDefault: Boolean): Neo4jClient
 

--- a/core/src/main/scala/me/jeffmay/neo4j/client/TxnResponse.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/TxnResponse.scala
@@ -1,11 +1,11 @@
 package me.jeffmay.neo4j.client
 
-import me.jeffmay.neo4j.client.cypher.Statement
+import me.jeffmay.neo4j.client.cypher.CypherStatement
 import org.joda.time.DateTime
 import play.api.libs.json._
 
 /**
-  * Represents the results of executing a batch of [[Statement]]s.
+  * Represents the results of executing a batch of [[CypherStatement]]s.
   */
 sealed trait TxnResponse {
 
@@ -37,12 +37,12 @@ sealed trait TxnResponse {
   def safeToRetry: Boolean = results.forall(_.data.isEmpty) && errors.forall(_.status.safeToRetry)
 
   /**
-    * The results of executing the [[Statement]]s returned in the same order as given.
+    * The results of executing the [[CypherStatement]]s returned in the same order as given.
     */
   def results: Seq[StatementResult]
 
   /**
-    * All the errors encountered when executing the [[Statement]]s within a transaction.
+    * All the errors encountered when executing the [[CypherStatement]]s within a transaction.
     */
   def errors: Seq[Neo4jError]
 

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/Cypher.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/Cypher.scala
@@ -5,13 +5,18 @@ import scala.language.{dynamics, implicitConversions}
 object Cypher {
 
   /**
-    * The canonical method to create a [[CypherLabel]] to insert into a CypherString.
-    *
-    * @see <a href="http://neo4j.com/docs/stable/graphdb-neo4j.html#graphdb-neo4j-labels">Label Documentation</a>
+    * The canonical method to create a [[CypherLabel]] to insert into the cypher query string.
     *
     * @return A [[CypherResult]] which can either contain the label or an error.
     */
-  def label(labelName: String): CypherResult[CypherLabel] = CypherLabel(labelName)
+  def label(name: String): CypherResult[CypherLabel] = CypherLabel(name)
+
+  /**
+    * The canonical method to create a [[CypherIdentifier]] to insert into a cypher query string.
+    *
+    * @return a [[CypherResult]] which can either contain the identifier or an error
+    */
+  def ident(name: String): CypherResult[CypherIdentifier] = CypherIdentifier(name)
 
   /**
     * The canonical method to create a [[CypherProps]] map.

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/Cypher.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/Cypher.scala
@@ -44,7 +44,7 @@ object Cypher {
     * }}}
     *
     * @param namespace the name of the parameters object as sent to the server
-    * @return a dynamic parameters builder for embedding into [[CypherStringContext]] interpolated [[Statement]]s
+    * @return a dynamic parameters builder for embedding into [[CypherStringContext]] interpolated [[CypherStatement]]s
     */
   def params(namespace: String): Params = new Params(namespace)
 

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/CypherArg.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/CypherArg.scala
@@ -79,7 +79,7 @@ case class CypherLabelInvalidFormat(literal: String) extends InvalidCypherArgFor
 
 /**
   * A valid argument to pass into the [[CypherStringContext]] used to insert some literal string or parameter(s)
-  * into a Cypher [[Statement]].
+  * into a Cypher [[CypherStatement]].
   */
 sealed trait CypherArg {
 
@@ -96,7 +96,7 @@ sealed trait CypherArg {
 /**
   * A literal string to insert into the Cypher string.
   *
-  * @param template the literal value to insert into the [[Statement.template]].
+  * @param template the literal value to insert into the [[CypherStatement.template]].
   */
 sealed abstract class CypherTemplatePart(override val template: String) extends CypherArg with Proxy {
   override def self: Any = template
@@ -106,7 +106,6 @@ sealed abstract class CypherTemplatePart(override val template: String) extends 
   * An identifier to refer to nodes, relationships, or paths in a pattern.
   *
   * @see <a href="http://neo4j.com/docs/stable/cypher-identifiers.html">Cypher Identifiers</a>
-  *
   * @param name the name of the identifier
   */
 final class CypherIdentifier private (name: String) extends CypherTemplatePart(name)
@@ -131,7 +130,6 @@ object CypherIdentifier {
   * A label to add to either a node or relationship.
   *
   * @see <a href="http://neo4j.com/docs/stable/graphdb-neo4j.html#graphdb-neo4j-labels">Label Documentation</a>
-  *
   * @param name the name of the label (without the preceding colon ':')
   */
 final class CypherLabel private (name: String) extends CypherTemplatePart(s":$name")
@@ -159,7 +157,7 @@ object CypherLabel {
 }
 
 /**
-  * Holds a single parameter in the [[Statement.parameters]].
+  * Holds a single parameter in the [[CypherStatement.parameters]].
   *
   * @note This is not constructed directly. Rather, you use the [[Cypher.params]] methods to build this.
   * @param namespace the key of the [[CypherProps]] within which field names are unique

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/CypherInterpolation.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/CypherInterpolation.scala
@@ -10,17 +10,15 @@ trait CypherInterpolation {
 class CypherStringContext(val sc: StringContext) extends AnyVal {
 
   /**
-    * Build a cypher [[Statement]] by interpolating the given [[CypherArg]]s.
+    * Build a cypher [[CypherStatement]] by interpolating the given [[CypherArg]]s.
     *
     * @param args the [[CypherResult]]s from which to extract the [[CypherArg]]s
-    *
-    * @return a [[Statement]] with the concatenated template and the the template and parameters
-    *         of the [[Statement]].
-    *
+    * @return a [[CypherStatement]] with the concatenated template and the the template and parameters
+    *         of the [[CypherStatement]].
     * @throws InvalidCypherException if any of the args are [[CypherResultInvalid]]
     * @throws DuplicatePropertyNameException if two [[CypherParam]]s share the same namespace and property name
     */
-  def cypher(args: CypherResult[CypherArg]*): Statement = {
+  def cypher(args: CypherResult[CypherArg]*): CypherStatement = {
     // Build the literal query string
     var count: Int = 0
     val tmplParts: Seq[String] = args.map {
@@ -54,6 +52,6 @@ class CypherStringContext(val sc: StringContext) extends AnyVal {
         }
         namespace -> props
       }
-    Statement(template, params)
+    CypherStatement(template, params)
   }
 }

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/CypherStatement.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/CypherStatement.scala
@@ -5,21 +5,19 @@ package me.jeffmay.neo4j.client.cypher
   *
   * @note You should always provide the parameters instead of inserting values directly into the query
   *       to prevent cypher injection attacks.
-  *
   * @see <a href="http://neo4j.com/docs/stable/rest-api-transactional.html">Transaction Documentation</a>
-  *
   * @param template     the literal Cypher string with parameter placeholders
   * @param parameters   a map of namespaces -> props objects containing the keys to substitute in the
   *                     template associated with the values. These parameters are safe from cypher
   *                     injection attacks when executed on the server.
   * @param includeStats whether to include the [[me.jeffmay.neo4j.client.StatementResultStats]] for this statement
   */
-case class Statement(
+case class CypherStatement(
   template: String,
   parameters: Map[String, CypherProps] = Map.empty,
   includeStats: Boolean = false
 ) {
-  def withStats: Statement = {
+  def withStats: CypherStatement = {
     if (includeStats) this
     else copy(includeStats = true)
   }

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/CypherStatement.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/CypherStatement.scala
@@ -5,7 +5,9 @@ package me.jeffmay.neo4j.client.cypher
   *
   * @note You should always provide the parameters instead of inserting values directly into the query
   *       to prevent cypher injection attacks.
+  *
   * @see <a href="http://neo4j.com/docs/stable/rest-api-transactional.html">Transaction Documentation</a>
+  *
   * @param template     the literal Cypher string with parameter placeholders
   * @param parameters   a map of namespaces -> props objects containing the keys to substitute in the
   *                     template associated with the values. These parameters are safe from cypher
@@ -17,8 +19,64 @@ case class CypherStatement(
   parameters: Map[String, CypherProps] = Map.empty,
   includeStats: Boolean = false
 ) {
+
+  /**
+    * Request that this statement include the stats
+    */
   def withStats: CypherStatement = {
     if (includeStats) this
     else copy(includeStats = true)
+  }
+
+  /**
+    * Provided as a mechanism for communicating the common error of appending a string to a string-looking statement.
+    *
+    * @note This does not protect you against appending a statement to a string.
+    */
+  @deprecated("Only append cypher\"\" interpolated strings with :+: to avoid cypher injection attacks", "0.4.0")
+  def +(literal: String): CypherStatement = this.copy(template + literal)
+
+  /**
+    * Prepends the left-hand-side statement's template to this template and merges the properties.
+    *
+    * @note `:+:` is right applicative, so `a :+: b` is actually `b.:+:(a)` and thus it prepends `a` to `b`
+    *
+    * @see [[concat]]
+    */
+  @inline final def :+:(that: CypherStatement): CypherStatement = that concat this
+
+  /**
+    * Appends the given statement's template to this template and merges the properties.
+    *
+    * @note WARNING: Any settings like "includeStats" drop back to the default.
+    *       You have to explicitly add the settings you want after concatenating the statements.
+    *
+    * @throws DuplicatePropertyNameException if the statements contain conflicting property values for a single
+    *                                        property name within a namespace.
+    */
+  def concat(that: CypherStatement): CypherStatement = {
+    val mergedTemplate = this.template + that.template
+    val conflictingNamespaces = this.parameters.keySet intersect that.parameters.keySet
+    var mergedOverrides = Seq.empty[(String, CypherProps)]
+    for (ns <- conflictingNamespaces) {
+      val thisParams = this.parameters(ns)
+      val thatParams = that.parameters(ns)
+      val conflictingParamKeys = thisParams.keySet intersect thatParams.keySet
+      for (key <- conflictingParamKeys) {
+        val duplicates = Set(thisParams(key), thatParams(key))
+        if (duplicates.size > 1) {
+          throw new DuplicatePropertyNameException(ns, key, duplicates.toSeq, mergedTemplate)
+        }
+      }
+      mergedOverrides :+= ns -> (thisParams ++ thatParams)
+    }
+    // Merge the parameters by iterating over the non-conflicting namespaces and appending the merged props
+    val mergedParams = (
+      (this.parameters.view ++ that.parameters.view).filterNot {
+        case (ns, _) => conflictingNamespaces(ns)
+      } ++
+        mergedOverrides.view
+      ).toMap
+    CypherStatement(mergedTemplate, mergedParams)
   }
 }

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/CypherStatement.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/CypherStatement.scala
@@ -16,7 +16,7 @@ package me.jeffmay.neo4j.client.cypher
   */
 case class CypherStatement(
   template: String,
-  parameters: Map[String, CypherProps] = Map.empty,
+  parameters: CypherParams = Map.empty,
   includeStats: Boolean = false
 ) {
 

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/exceptions.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/exceptions.scala
@@ -1,7 +1,7 @@
 package me.jeffmay.neo4j.client.cypher
 
 /**
-  * An exception thrown when there is an error constructing a [[CypherArg]] or [[Statement]].
+  * An exception thrown when there is an error constructing a [[CypherArg]] or [[CypherStatement]].
   */
 sealed abstract class CypherException(message: String) extends Exception(message)
 

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/exceptions.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/exceptions.scala
@@ -27,9 +27,26 @@ class InvalidCypherException(val message: String, val causes: Seq[CypherResultIn
 }
 
 /**
-  * An exception thrown
-  * @param namespace
-  * @param property
+  * An exception thrown when a property is defined twice on the same namespace in the same template.
+  *
+  * @param namespace the namespace within which the [[CypherProps]] live
+  * @param property the name of the property within the [[CypherProps]]
+  * @param template the raw cypher template for debugging purposes
   */
-class DuplicatePropertyNameException(val namespace: String, val property: String, val template: String)
-  extends CypherException(s"'$property' has already been defined for the props object named '$namespace' in:\n$template")
+class DuplicatePropertyNameException(
+  val namespace: String,
+  val property: String,
+  val conflictingValues: Seq[CypherValue],
+  val template: String
+) extends CypherException(
+    s"'$property' has already been defined for the props object named '$namespace' in:\n" +
+    s"$template\n" +
+    s"Conflicting values are: ${conflictingValues.mkString(", ")}"
+  ) {
+  private[this] val conflictingValueSet = conflictingValues.toSet
+  assert(
+    conflictingValueSet.size >= 2,
+    "This exception should not be thrown when there is less than 2 distinct conflicting values.\n" +
+    s"Given: $conflictingValueSet"
+  )
+}

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/package.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/package.scala
@@ -7,5 +7,10 @@ package me.jeffmay.neo4j.client
 package object cypher extends CypherInterpolation {
 
   type CypherProps = Map[String, CypherValue]
+
+  @deprecated("Use CypherStatement instead", "0.4.0")
+  type Statement = CypherStatement
+  @deprecated("Use CypherStatement instead", "0.4.0")
+  val Statement = CypherStatement
 }
 

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/package.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/package.scala
@@ -8,6 +8,8 @@ package object cypher extends CypherInterpolation {
 
   type CypherProps = Map[String, CypherValue]
 
+  type CypherParams = Map[String, CypherProps]
+
   @deprecated("Use CypherStatement instead", "0.4.0")
   type Statement = CypherStatement
   @deprecated("Use CypherStatement instead", "0.4.0")

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/scalacheck/CypherStatementGenerators.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/scalacheck/CypherStatementGenerators.scala
@@ -26,7 +26,7 @@ trait CypherStatementGenerators extends CypherValueGenerators {
   /**
     * Generates the parameters of a [[CypherStatement]].
     */
-  lazy val genCypherParams: Gen[Map[String, CypherProps]] = {
+  lazy val genCypherParams: Gen[CypherParams] = {
     Gen.mapOf(Gen.zip(
       Gen.identifier,
       Gen.mapOf(Gen.zip(
@@ -53,7 +53,7 @@ trait CypherStatementGenerators extends CypherValueGenerators {
     * @note the explicit cases of handling empty parameter object names is tested within this library,
     *       so you shouldn't need to generate invalid inputs.
     */
-  implicit val shrinkCypherParams: Shrink[Map[String, CypherProps]] = Shrink { params =>
+  implicit val shrinkCypherParams: Shrink[CypherParams] = Shrink { params =>
     implicit val shrinkIdentifier = Shrink[String](id => Shrink.shrink[String](id).filterNot(_.isEmpty))
     Shrink.shrinkContainer2[Map, String, CypherProps].shrink(params)
   }

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/scalacheck/CypherStatementGenerators.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/scalacheck/CypherStatementGenerators.scala
@@ -1,0 +1,60 @@
+package me.jeffmay.neo4j.client.cypher.scalacheck
+
+import me.jeffmay.neo4j.client.cypher._
+import org.scalacheck.{Shrink, Gen}
+
+object CypherStatementGenerators extends CypherStatementGenerators
+trait CypherStatementGenerators extends CypherValueGenerators {
+
+  /**
+    * Generates a valid field name where the first character is alphabetical and the remaining chars
+    * are alphanumeric.
+    */
+  def genFieldName: Gen[String] = Gen.identifier
+
+  def genFields: Gen[(String, CypherValue)] = Gen.zip(genFieldName, genCypherValue)
+
+  /**
+    * Generates a nested array at the specified depth and width.
+    */
+  lazy val genCypherProps: Gen[CypherProps] = {
+    for {
+      fields <- Gen.listOf(genFields)
+    } yield Map(fields: _*)
+  }
+
+  /**
+    * Generates the parameters of a [[CypherStatement]].
+    */
+  lazy val genCypherParams: Gen[Map[String, CypherProps]] = {
+    Gen.mapOf(Gen.zip(
+      Gen.identifier,
+      Gen.mapOf(Gen.zip(
+        Gen.identifier,
+        genCypherValue
+      ))
+    ))
+  }
+
+  /**
+    * Avoids shrinking property names to empty strings, since these would be invalid.
+    *
+    * @note the explicit cases of handling empty property names is tested within this library,
+    *       so you shouldn't need to generate invalid inputs.
+    */
+  implicit val shrinkCypherProps: Shrink[CypherProps] = Shrink { params =>
+    implicit val shrinkIdentifier = Shrink[String](id => Shrink.shrink[String](id).filterNot(_.isEmpty))
+    Shrink.shrinkContainer2[Map, String, CypherValue].shrink(params)
+  }
+
+  /**
+    * Avoids shrinking parameter object names to empty strings, since these would be invalid.
+    *
+    * @note the explicit cases of handling empty parameter object names is tested within this library,
+    *       so you shouldn't need to generate invalid inputs.
+    */
+  implicit val shrinkCypherParams: Shrink[Map[String, CypherProps]] = Shrink { params =>
+    implicit val shrinkIdentifier = Shrink[String](id => Shrink.shrink[String](id).filterNot(_.isEmpty))
+    Shrink.shrinkContainer2[Map, String, CypherProps].shrink(params)
+  }
+}

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/scalacheck/CypherValueGenerators.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/scalacheck/CypherValueGenerators.scala
@@ -1,8 +1,8 @@
 package me.jeffmay.neo4j.client.cypher.scalacheck
 
 import me.jeffmay.neo4j.client.cypher._
-import org.scalacheck.{Shrink, Gen, Arbitrary}
 import org.scalacheck.Shrink.shrink
+import org.scalacheck.{Arbitrary, Gen, Shrink}
 
 import scala.language.implicitConversions
 
@@ -106,23 +106,6 @@ trait CypherValueGenerators {
 
   lazy val genCypherValue: Gen[CypherValue] = {
     Gen.oneOf(genCypherPrimitive, genCypherArray)
-  }
-
-  /**
-    * Generates a valid field name where the first character is alphabetical and the remaining chars
-    * are alphanumeric.
-    */
-  def genFieldName: Gen[String] = Gen.identifier
-
-  def genFields: Gen[(String, CypherValue)] = Gen.zip(genFieldName, genCypherValue)
-
-  /**
-    * Generates a nested array at the specified depth and width.
-    */
-  lazy val genCypherProps: Gen[CypherProps] = {
-    for {
-      fields <- Gen.listOf(genFields)
-    } yield Map(fields: _*)
   }
 
   // Shrinks for better error output

--- a/core/src/main/scala/me/jeffmay/neo4j/client/cypher/scalacheck/package.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/cypher/scalacheck/package.scala
@@ -1,3 +1,3 @@
 package me.jeffmay.neo4j.client.cypher
 
-package object scalacheck extends CypherValueGenerators
+package object scalacheck extends CypherValueGenerators with CypherStatementGenerators

--- a/core/src/main/scala/me/jeffmay/neo4j/client/results.scala
+++ b/core/src/main/scala/me/jeffmay/neo4j/client/results.scala
@@ -1,10 +1,10 @@
 package me.jeffmay.neo4j.client
 
 import play.api.libs.json._
-import me.jeffmay.neo4j.client.cypher.Statement
+import me.jeffmay.neo4j.client.cypher.CypherStatement
 
 /**
-  * A result from a single [[Statement]].
+  * A result from a single [[CypherStatement]].
   *
   * @param columns a map of column names to index
   * @param data    the table of rows / columns of json values to be parsed
@@ -70,7 +70,7 @@ object StatementResultRow {
 }
 
 /**
-  * Stats about the effects of executing the [[Statement]].
+  * Stats about the effects of executing the [[CypherStatement]].
   *
   * @param containsUpdates whether the statement contained updates
   * @param nodesCreated the number of nodes created

--- a/core/src/test/scala/me/jeffmay/neo4j/client/cypher/CypherStatementSpec.scala
+++ b/core/src/test/scala/me/jeffmay/neo4j/client/cypher/CypherStatementSpec.scala
@@ -1,0 +1,81 @@
+package me.jeffmay.neo4j.client.cypher
+
+import org.scalatest.WordSpec
+import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+import scalacheck._
+
+class CypherStatementSpec extends WordSpec {
+
+  "CypherStatement" when {
+
+    "interpolated" should {
+
+      "allowed merging parameters that share the same namespace and key and they have the same value" in {
+        val props = Cypher.params("props")
+        val value = props.ref(1)
+        assertResult(CypherStatement(
+          "MATCH (n { ref: {props}.ref }) --> (m { ref: {props}.ref })",
+          Map("props" -> Cypher.props("ref" -> 1))
+        )) {
+          cypher"MATCH (n { ref: $value }) --> (m { ref: $value })"
+        }
+      }
+
+      "throw an exception when statement parameters share the same namespace and key but with different values" in {
+        val props = Cypher.params("props")
+        val ex = intercept[DuplicatePropertyNameException] {
+          cypher"MATCH (n { ref: ${props.ref(1)} }) --> (m { ref: ${props.ref(2)} })"
+        }
+        assertResult(Seq(CypherInt(1), CypherInt(2)))(ex.conflictingValues)
+      }
+    }
+
+    "concatenated" should {
+
+      "append raw template strings" in {
+        assertResult(cypher"ab") {
+          cypher"a" :+: cypher"b"
+        }
+      }
+
+      "append a string literal to the template" in {
+        assertResult(cypher"ab") {
+          cypher"a" + "b"
+        }
+      }
+
+      "allowed merging parameters that share the same namespace and key and they have the same value" in {
+        val props = Cypher.params("props")
+        val value = props.ref(1)
+        assertResult(CypherStatement(
+          "MATCH (n { ref: {props}.ref }) --> (m { ref: {props}.ref })",
+          Map("props" -> Cypher.props("ref" -> 1))
+        )) {
+          cypher"MATCH (n { ref: $value })" :+: cypher" --> (m { ref: $value })"
+        }
+      }
+
+      "throw an exception when statement parameters share the same namespace and key but with different values" in {
+        val props = Cypher.params("props")
+        val ex = intercept[DuplicatePropertyNameException] {
+          cypher"MATCH (n { ref: ${props.ref(1)} })" :+: cypher" --> (m { ref: ${props.ref(2)} })"
+        }
+        assertResult(Seq(CypherInt(1), CypherInt(2)))(ex.conflictingValues)
+      }
+
+      "merge all properties given" in {
+        forAll(genCypherParams) { (params: Map[String, CypherProps]) =>
+          val expectedParams = params.filter(_._2.nonEmpty)
+          val result = params.foldLeft(cypher"") {
+            case (acc, (ns, propValues)) =>
+              val props = Cypher.params(ns)
+              propValues.foldLeft(acc) {
+                case (c, (k, v)) => c :+: cypher"${props.applyDynamic(k)(v)}"
+              }
+          }
+          assertResult(expectedParams)(result.parameters)
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/me/jeffmay/neo4j/client/cypher/CypherStatementSpec.scala
+++ b/core/src/test/scala/me/jeffmay/neo4j/client/cypher/CypherStatementSpec.scala
@@ -64,7 +64,7 @@ class CypherStatementSpec extends WordSpec {
       }
 
       "merge all properties given" in {
-        forAll(genCypherParams) { (params: Map[String, CypherProps]) =>
+        forAll(genCypherParams) { (params: CypherParams) =>
           val expectedParams = params.filter(_._2.nonEmpty)
           val result = params.foldLeft(cypher"") {
             case (acc, (ns, propValues)) =>

--- a/core/src/test/scala/me/jeffmay/neo4j/client/cypher/CypherStringContextSpec.scala
+++ b/core/src/test/scala/me/jeffmay/neo4j/client/cypher/CypherStringContextSpec.scala
@@ -37,6 +37,17 @@ class CypherStringContextSpec extends WordSpec
       }
     }
 
+    "allow literal substitution for identifiers" in {
+      val stmt = cypher"MATCH (${Cypher.ident("n")}) RETURN n"
+      val expectedTemplate = "MATCH (n) RETURN n"
+      assertResult(expectedTemplate, "template did not render properly") {
+        stmt.template
+      }
+      assertResult(Map.empty) {
+        stmt.parameters
+      }
+    }
+
     "allow literal substitution for labels" in {
       val stmt = cypher"MATCH (n ${Cypher.label("EXPECTED")}) RETURN n"
       val expectedTemplate = "MATCH (n :EXPECTED) RETURN n"

--- a/test-util/src/main/scala/me/jeffmay/neo4j/client/Neo4jTestNamespace.scala
+++ b/test-util/src/main/scala/me/jeffmay/neo4j/client/Neo4jTestNamespace.scala
@@ -1,6 +1,6 @@
 package me.jeffmay.neo4j.client
 
-import me.jeffmay.neo4j.client.cypher.{Cypher, Statement}
+import me.jeffmay.neo4j.client.cypher.{Cypher, CypherStatement}
 import me.jeffmay.util.Namespace
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -9,7 +9,7 @@ object Neo4jTestNamespace {
 
   def cleanup(namespace: Namespace, client: Neo4jClient)(implicit ec: ExecutionContext): Future[Any] = {
     client.openAndCommitTxn(
-      Statement("MATCH (n { ns: {props}.ns }) OPTIONAL MATCH (n)-[r]-() DELETE n, r",
+      CypherStatement("MATCH (n { ns: {props}.ns }) OPTIONAL MATCH (n)-[r]-() DELETE n, r",
         Map("props" -> Cypher.props("ns" -> namespace.value))
       )
     )

--- a/ws/src/main/scala/me/jeffmay/neo4j/client/rest/requests.scala
+++ b/ws/src/main/scala/me/jeffmay/neo4j/client/rest/requests.scala
@@ -1,6 +1,6 @@
 package me.jeffmay.neo4j.client.rest
 
-import me.jeffmay.neo4j.client.cypher.{CypherProps, Statement}
+import me.jeffmay.neo4j.client.cypher.{CypherProps, CypherStatement}
 import play.api.libs.json.{JsObject, Json, OWrites, Writes}
 
 import scala.language.implicitConversions
@@ -17,13 +17,13 @@ private[client] case class RawStatementTransactionRequest(
 private[client] object RawStatementTransactionRequest {
   implicit val writer: Writes[RawStatementTransactionRequest] = Json.writes[RawStatementTransactionRequest]
 
-  def fromCypherStatements(statements: Seq[Statement]): RawStatementTransactionRequest = {
+  def fromCypherStatements(statements: Seq[CypherStatement]): RawStatementTransactionRequest = {
     new RawStatementTransactionRequest(statements.map(RawRequestStatement.fromCypherStatement))
   }
 }
 
 /**
-  * The json representation of a [[Statement]] for Neo4j's REST API.
+  * The json representation of a [[CypherStatement]] for Neo4j's REST API.
   *
   * @param statement the query string
   * @param parameters the parameters to substitute into the query string
@@ -38,7 +38,7 @@ private[client] case class RawRequestStatement(
 private[client] object RawRequestStatement {
   implicit val jsonWriter: Writes[RawRequestStatement] = Json.writes[RawRequestStatement]
 
-  def fromCypherStatement(statement: Statement): RawRequestStatement = {
+  def fromCypherStatement(statement: CypherStatement): RawRequestStatement = {
     new RawRequestStatement(
       statement.template,
       OWrites.map[CypherProps].writes(statement.parameters),

--- a/ws/src/main/scala/me/jeffmay/neo4j/client/rest/responses.scala
+++ b/ws/src/main/scala/me/jeffmay/neo4j/client/rest/responses.scala
@@ -1,7 +1,7 @@
 package me.jeffmay.neo4j.client.rest
 
 import me.jeffmay.neo4j.client._
-import me.jeffmay.neo4j.client.cypher.Statement
+import me.jeffmay.neo4j.client.cypher.CypherStatement
 import org.joda.time.DateTime
 import play.api.libs.json._
 
@@ -113,7 +113,7 @@ private[client] object RawTxnInfo {
 }
 
 /**
-  * Stats about the result of running a single [[Statement]].
+  * Stats about the result of running a single [[CypherStatement]].
   */
 private[client] case class RawResultStats(
   contains_updates: Boolean,
@@ -156,7 +156,7 @@ private[client] object RawResultStats {
 }
 
 /**
-  * The result of running a single [[Statement]]
+  * The result of running a single [[CypherStatement]]
   */
 private[client] case class RawStatementResult(
   columns: Seq[String],

--- a/ws/src/main/scala/me/jeffmay/neo4j/client/ws/WSNeo4jClient.scala
+++ b/ws/src/main/scala/me/jeffmay/neo4j/client/ws/WSNeo4jClient.scala
@@ -3,7 +3,7 @@ package me.jeffmay.neo4j.client.ws
 import akka.actor.Scheduler
 import me.jeffmay.neo4j.client
 import me.jeffmay.neo4j.client._
-import me.jeffmay.neo4j.client.cypher.Statement
+import me.jeffmay.neo4j.client.cypher.CypherStatement
 import me.jeffmay.neo4j.client.StatusCodeException
 import me.jeffmay.neo4j.client.rest._
 import me.jeffmay.util.ws.{ProxyWSClient, TimeoutWSRequest}
@@ -74,7 +74,7 @@ class WSNeo4jClient(
       .map(_ => ())
   }
 
-  override def openTxn(statements: Statement*): Future[OpenedTxnResponse] = {
+  override def openTxn(statements: CypherStatement*): Future[OpenedTxnResponse] = {
     val rawBody = RawStatementTransactionRequest.fromCypherStatements(statements)
     val jsonBody = Json.toJson(rawBody)
     val request = http("/db/data/transaction")
@@ -90,7 +90,7 @@ class WSNeo4jClient(
     }
   }
 
-  override def openAndCommitTxn(first: Statement, others: Statement*): Future[CommittedTxnResponse] = {
+  override def openAndCommitTxn(first: CypherStatement, others: CypherStatement*): Future[CommittedTxnResponse] = {
     val rawBody = RawStatementTransactionRequest.fromCypherStatements(first +: others)
     val jsonBody = Json.toJson(rawBody)
     val request = http("/db/data/transaction/commit")
@@ -109,7 +109,7 @@ class WSNeo4jClient(
     }
   }
 
-  override def commitTxn(ref: TxnRef, alongWith: Statement*): Future[CommittedTxnResponse] = {
+  override def commitTxn(ref: TxnRef, alongWith: CypherStatement*): Future[CommittedTxnResponse] = {
     val rawBody = RawStatementTransactionRequest.fromCypherStatements(alongWith)
     val jsonBody = Json.toJson(rawBody)
     val request = http("/db/data/transaction")

--- a/ws/src/test/scala/me/jeffmay/neo4j/client/FixtureQueries.scala
+++ b/ws/src/test/scala/me/jeffmay/neo4j/client/FixtureQueries.scala
@@ -1,6 +1,6 @@
 package me.jeffmay.neo4j.client
 
-import me.jeffmay.neo4j.client.cypher.{Cypher, Statement}
+import me.jeffmay.neo4j.client.cypher.{Cypher, CypherStatement}
 import me.jeffmay.util.Namespace
 
 object FixtureQueries extends FixtureQueries
@@ -11,8 +11,8 @@ trait FixtureQueries {
    */
 
   object CreateNode {
-    def query(id: String, includeStats: Boolean = true)(implicit ns: Namespace): Statement = {
-      Statement(
+    def query(id: String, includeStats: Boolean = true)(implicit ns: Namespace): CypherStatement = {
+      CypherStatement(
         "CREATE (n { ns: {props}.ns, id: {props}.id })",
         Map("props" -> Cypher.props(
           "id" -> id,
@@ -27,8 +27,8 @@ trait FixtureQueries {
   }
 
   object RenameNode {
-    def query(id: String, newId: String, includeStats: Boolean = true)(implicit ns: Namespace): Statement = {
-      Statement(
+    def query(id: String, newId: String, includeStats: Boolean = true)(implicit ns: Namespace): CypherStatement = {
+      CypherStatement(
         "MATCH (n { ns: {props}.ns, id: {props}.id }) SET n.id = {new}.id",
         Map(
           "props" -> Cypher.props(
@@ -48,8 +48,8 @@ trait FixtureQueries {
   }
 
   object AddLabel {
-    def query(id: String, label: String, includeStats: Boolean = true)(implicit ns: Namespace): Statement = {
-      Statement(
+    def query(id: String, label: String, includeStats: Boolean = true)(implicit ns: Namespace): CypherStatement = {
+      CypherStatement(
         s"MATCH (n { ns: {props}.ns, id: {props}.id }) SET n ${Cypher.label(label).getOrThrow.template}",
         Map(
           "props" -> Cypher.props(

--- a/ws/src/test/scala/me/jeffmay/neo4j/client/ws/WSNeo4jClientBasicSpecs.scala
+++ b/ws/src/test/scala/me/jeffmay/neo4j/client/ws/WSNeo4jClientBasicSpecs.scala
@@ -1,7 +1,7 @@
 package me.jeffmay.neo4j.client.ws
 
 import me.jeffmay.neo4j.client._
-import me.jeffmay.neo4j.client.cypher.{Cypher, Statement}
+import me.jeffmay.neo4j.client.cypher.{Cypher, CypherStatement}
 import me.jeffmay.util.UniquePerClassNamespace
 import me.jeffmay.util.akka.TestGlobalAkka
 import org.scalatest._
@@ -50,7 +50,7 @@ class WSNeo4jClientBasicSpecs extends fixture.AsyncWordSpec
 
       "start with an empty unique namespace" in { fixture =>
         import fixture._
-        val getAllNodes = Statement(
+        val getAllNodes = CypherStatement(
           "MATCH (n { ns: {props}.ns }) RETURN n",
           Map("props" -> Cypher.props("ns" -> namespace.value))
         )


### PR DESCRIPTION
@audax-shreyaspurohit @mingy711 @macmacbr @danstaley
- Added support for `Cypher.ident` to create bindings.
- Added support for `:+:` operator for concatenating cypher statements
- Renamed `Statement` to `CypherStatement`
